### PR TITLE
Remove creation of id for game and studio from services

### DIFF
--- a/GameStore.Services/Services/Implementation/GameServices.cs
+++ b/GameStore.Services/Services/Implementation/GameServices.cs
@@ -54,8 +54,6 @@ namespace GameStore.Services.Services.Implementation
                 throw new ArgumentNullException();
             }
 
-
-            item.Id = Guid.NewGuid();
             var gameEntity = GameStoreMapper.Map<GameModel, Game>(item);
             gameEntity.Producers = item.Producers.Select(x => producerRepository.GetItemById(x.Id)).ToList();
             return gameRepository.Add(gameEntity);
@@ -68,7 +66,6 @@ namespace GameStore.Services.Services.Implementation
                 throw new ArgumentNullException();
             }
 
-            item.Id = Guid.NewGuid();
             item.Image = path;
             var gameEntity = GameStoreMapper.Map<GameCreationTransferModel, Game>(item);
 

--- a/GameStore.Services/Services/Implementation/StudioServices.cs
+++ b/GameStore.Services/Services/Implementation/StudioServices.cs
@@ -26,7 +26,6 @@ namespace GameStore.Services.Services.Implementation
                 throw new ArgumentNullException();
             }
 
-            item.Id = Guid.NewGuid();
             var studioEntity = GameStoreMapper.Map<StudioModel, Studio>(item);
             return studioRepository.Add(studioEntity);
         }


### PR DESCRIPTION
There was removed operation of id's creation for game and studio from services because this step is implemented in the repositories.